### PR TITLE
Load only current user's files

### DIFF
--- a/app/controllers/files/files_controller.rb
+++ b/app/controllers/files/files_controller.rb
@@ -16,7 +16,7 @@ class Files::FilesController < ApplicationController
   end
 
   def show_all
-    @bruse_files = BruseFile.all
+    @bruse_files = current_user.bruse_files
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :confirmable
   # relations
   has_many :identities
+  has_many :bruse_files, through: :identities
   belongs_to :default_identity, class_name: "Identity"
 
   # validations


### PR DESCRIPTION
`files/files#show_all` used to load every file in the `BruseFile` model. By adding a has_many bruse_files through identities relationship to the user model we can replace this insecure `BruseFile` load with only the `BruseFiles` belonging to `identities` belonging to the `current_user`.
