### PR TITLE
Feature/handle drive specific files

### DIFF
--- a/app/assets/javascripts/factories/FileHandler.coffee
+++ b/app/assets/javascripts/factories/FileHandler.coffee
@@ -91,6 +91,8 @@
           filetype: file.mimeType
           # send info whether or not this is a directory to server
           is_dir: file.is_dir
+          # set link
+          link: file.alternateLink
           # store some useful meta data
           meta:
             size: file.fileSize

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -28,7 +28,12 @@
               {{file.name}}
             </span>
           </td>
-          <td>.{{getFiletype(file.filetype)}}</td>
+          <td ng-if="file.filetype.indexOf('google-apps') > -1">
+            {{getFiletype(file.filetype).slice(16,end)}}
+          </td>
+          <td ng-if="file.filetype.indexOf('google-apps') < 0">
+            {{getFiletype(file.filetype)}}
+          </td>
           <td>{{file.identity.name}}</td>
           <td>{{file.date}}</td>
           <td>

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -21,7 +21,10 @@
             <a ng-if="file.filetype === 'bruse/url'" ng-href="{{file.url}}" target="_blank">
               {{file.name}}
             </a>
-            <span ng-if="file.filetype != 'bruse/url'" ng-click="download(file.identity.id, file)">
+            <a ng-if="file.filetype.indexOf('google-apps') > -1" ng-href="{{file.link}}" target="_blank">
+              {{file.name}}
+            </a>
+            <span ng-if="file.filetype != 'bruse/url' && file.filetype.indexOf('google-apps') < 0" ng-click="download(file.identity.id, file)">
               {{file.name}}
             </span>
           </td>

--- a/app/controllers/files/files_controller.rb
+++ b/app/controllers/files/files_controller.rb
@@ -102,7 +102,7 @@ class Files::FilesController < ApplicationController
     #
     # Return safer parameters
     def file_params
-      params.require(:file).permit(:name, :foreign_ref, :filetype, :meta)
+      params.require(:file).permit(:name, :foreign_ref, :filetype, :meta, :link)
     end
 
     def text_params

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -170,7 +170,7 @@ class Identity < ActiveRecord::Base
 
     # return file data
     return @client.get_file(foreign_ref) if service.downcase.include? "dropbox"
-    return @client.get_file('https://www.googleapis.com/drive/v2/files/'+foreign_ref+'alt=media') if service.downcase.include? "google"
+    return @client.execute(:uri => 'https://www.googleapis.com/drive/v2/files/'+foreign_ref+'?alt=media') if service.downcase.include? "google"
     return File.read(Rails.root.join('usercontent', foreign_ref)) if service == "local"
   end
 

--- a/app/views/files/files/_file.json.jbuilder
+++ b/app/views/files/files/_file.json.jbuilder
@@ -2,6 +2,7 @@ json.name file.name
 json.filetype file.filetype
 json.date file.created_at.strftime("%F %R")
 json.id file.id
+json.link file.link if file.link?
 json.url file.foreign_ref if file.filetype == "bruse/url"
 json.add_tags_path
 json.paths do

--- a/db/migrate/20150421092907_add_link_to_bruse_files.rb
+++ b/db/migrate/20150421092907_add_link_to_bruse_files.rb
@@ -1,0 +1,5 @@
+class AddLinkToBruseFiles < ActiveRecord::Migration
+  def change
+    add_column :bruse_files, :link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150409092147) do
+ActiveRecord::Schema.define(version: 20150421092907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 20150409092147) do
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
     t.string   "download_hash"
+    t.string   "link"
   end
 
   create_table "bruse_files_tags", force: :cascade do |t|
@@ -80,6 +81,7 @@ ActiveRecord::Schema.define(version: 20150409092147) do
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
     t.boolean  "own_password",           default: true
+    t.integer  "default_identity_id"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
Added files that are drive specific like drive document or spreadsheet will be clickable.
When clicked the edit page in drive for the file opens.
If it is not a drive specific file (but from drive), it gets downloaded.
