### PR TITLE
delete tag if it has no file relation

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -49,6 +49,11 @@ class TagsController < ApplicationController
         @file.tags.delete(@tag)
     end
 
+    # If tag has no file relation, remove
+    if !@tag.bruse_files[0]
+      @tag.delete
+    end
+
     respond_to do |format|
       format.html { redirect_to bruse_files_url, notice: 'Deleted tag: ' + @tag.name.to_s}
       format.json { head :no_content }

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -50,7 +50,7 @@ class TagsController < ApplicationController
     end
 
     # If tag has no file relation, remove
-    if !@tag.bruse_files[0]
+    if @tag.bruse_files.empty?
       @tag.delete
     end
 


### PR DESCRIPTION
When a tag is removed from a file it checks if the tag has any relations with other files. If it hasn't e.g. the tag is unused, it gets removed.

To check if it works add a tag or more to your files, remove one tag that the other tags don't have and use rails c with the command Tag.all to see which tags you have. The tag that you removed should not be there.
