### PR TITLE
Feature/extend file template

### DIFF
--- a/app/assets/javascripts/controllers/FileCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileCtrl.coffee
@@ -97,6 +97,7 @@
    * save all files to db
   ###
   $scope.save = ->
+    NProgress.start()
     $rootScope.new_files = $scope.new_files
     _.each $scope.new_files, (file, index) ->
       FileHandler.put($scope.identity, file).then((data) ->
@@ -107,6 +108,7 @@
         # remove file from lists of files to add
         if index is $scope.new_files.length
           # do something better here
+          NProgress.done()
           $location.path('/service/'+$scope.identity.id+'/files/add/tag')
           console.log "done!"
         )

--- a/app/assets/javascripts/controllers/FileCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileCtrl.coffee
@@ -8,7 +8,7 @@
   $scope.identity = IDENTITY_PARAMS
 
   # load existing BruseFiles on page load
-  FileHandler.collect($scope.identity).then((data) ->
+  FileHandler.collect(identity: $scope.identity).then((data) ->
     $scope.bruse_files = data
 
     # when we have loaded BruseFiles, load root remote files

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -1,5 +1,5 @@
 # This provides the bFileList directive with some power
-@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', '$http', 'FileHandler', ($scope, $filter, $http, FileHandler) ->
+@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', ($scope, $filter, FileHandler) ->
   # since we use 'this' in some function below, we need to make sure they are
   # use the the controller as the 'this', and not the function
   self = this
@@ -15,10 +15,10 @@
       # if file is provided through the directive attributes, use those...
       $scope.files = attrs.files
     else if attrs.path
-      $http.get(attrs.path)
-        .success((data) ->
-          $scope.files = data.files
-          )
+      # ... or use the path provided to the directive...
+      FileHandler.collect(path: attrs.path).then((data) ->
+        $scope.files = data
+        )
     else
       # ... otherwise collect them from server
       FileHandler.collect().then((data) ->

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -1,5 +1,5 @@
 # This provides the bFileList directive with some power
-@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', ($scope, $filter, FileHandler) ->
+@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', '$http', 'FileHandler', ($scope, $filter, $http, FileHandler) ->
   # since we use 'this' in some function below, we need to make sure they are
   # use the the controller as the 'this', and not the function
   self = this
@@ -14,6 +14,11 @@
     if attrs.files
       # if file is provided through the directive attributes, use those...
       $scope.files = attrs.files
+    else if attrs.path
+      $http.get(attrs.path)
+        .success((data) ->
+          $scope.files = data.files
+          )
     else
       # ... otherwise collect them from server
       FileHandler.collect().then((data) ->

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -22,11 +22,19 @@
       absoluteLimit = 100
 
       recursiveCollect = ->
+        # show loading indicator
+        NProgress.start()
         FileHandler.collect(path: attrs.path, limit: limit, offset: offset).then((data) ->
+          # tick loading indicator!
+          NProgress.inc()
           # check if we should load more?
           if data.length >= limit && offset < absoluteLimit
             offset += limit
             recursiveCollect()
+          else
+            # hide loading indicator
+            NProgress.done()
+
           # iterate over all the collected files
           data.map((file) ->
             # extract tag names

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -59,6 +59,10 @@
       file.tags = data.tags
       file.editTags = false
       )
+  $scope.cutTag = (file, tag_id) ->
+    TagHandler.cut(file.id, tag_id).then((data) ->
+      file.tags = data.tags
+      )
 
   $scope.identities = ->
     return [] unless $scope.hasFiles()

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -1,11 +1,12 @@
 # This provides the bFileList directive with some power
-@bruseApp.controller 'FileListCtrl', ['$scope', 'FileHandler', ($scope, FileHandler) ->
+@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', ($scope, $filter, FileHandler) ->
   # since we use 'this' in some function below, we need to make sure they are
   # use the the controller as the 'this', and not the function
   self = this
   # setup some vars
   $scope.files = []
   $scope.view_list = true
+  $scope.showIdentities = []
 
   # this function gets called from the directive
   this.init = (element, attrs) ->
@@ -40,6 +41,11 @@
         # open the returned url in a new tab
         win = window.open('/'+data.url, '_self')
         )
+
+  $scope.identities = ->
+    return [] unless $scope.hasFiles()
+    uniqueIdentities = _.uniq($scope.files, 'identity.name')
+    _.pluck(uniqueIdentities, 'identity')
 
   # change mime to only filetype
   $scope.getFiletype = (mimetype) ->

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -1,5 +1,5 @@
 # This provides the bFileList directive with some power
-@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', ($scope, $filter, FileHandler) ->
+@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', 'TagHandler', 'JSTagsCollection', ($scope, $filter, FileHandler, TagHandler, JSTagsCollection) ->
   # since we use 'this' in some function below, we need to make sure they are
   # use the the controller as the 'this', and not the function
   self = this
@@ -41,6 +41,17 @@
         # open the returned url in a new tab
         win = window.open('/'+data.url, '_self')
         )
+
+  $scope.editTags = (file) ->
+    onlyTags = _.pluck(file.tags, 'name')
+    file.unsavedTags = new JSTagsCollection();
+    file.jsTagOptions =
+      "defaultTags": onlyTags
+      texts:
+        inputPlaceHolder: "Tag"
+      tags: file.unsavedTags
+      breakCodes: [32, 13, 9, 44] #space, enter, tab, comma
+    file.tagsEdit = true
 
   $scope.identities = ->
     return [] unless $scope.hasFiles()

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -14,16 +14,25 @@
     if attrs.files
       # if file is provided through the directive attributes, use those...
       $scope.files = attrs.files
-    else if attrs.path
-      # ... or use the path provided to the directive...
-      FileHandler.collect(path: attrs.path).then((data) ->
-        $scope.files = data
-        )
     else
+      # ... or use the path provided to the directive...
       # ... otherwise collect them from server
-      FileHandler.collect().then((data) ->
-        $scope.files = data
-        )
+      offset = 0
+      limit = 20
+      absoluteLimit = 100
+
+      recursiveCollect = ->
+        FileHandler.collect(path: attrs.path, limit: limit, offset: offset).then((data) ->
+          # check if we should load more?
+          if data.length >= limit && offset < absoluteLimit
+            offset += limit
+            recursiveCollect()
+          # append every file to the list of files
+          data.map((file) ->
+            $scope.files.push file
+            )
+          )
+      recursiveCollect()
 
   # Gets called when a file is clicked
   $scope.download = (identity_id, file) ->

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -2,7 +2,7 @@
 @bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', ($scope, $filter, FileHandler) ->
   # since we use 'this' in some function below, we need to make sure they are
   # use the the controller as the 'this', and not the function
-  self = this;
+  self = this
   # setup some vars
   orderBy = $filter('orderBy')
   $scope.files = []
@@ -11,7 +11,6 @@
   # this function gets called from the directive
   this.init = (element, attrs) ->
     self.$element = element
-    $scope.name = attrs.name
     if attrs.files
       # if file is provided through the directive attributes, use those...
       $scope.files = attrs.files

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -27,8 +27,19 @@
           if data.length >= limit && offset < absoluteLimit
             offset += limit
             recursiveCollect()
-          # append every file to the list of files
+          # iterate over all the collected files
           data.map((file) ->
+            # extract tag names
+            onlyTags = _.pluck(file.tags, 'name')
+            # append jsTag stuff to every file
+            file.unsavedTags = new JSTagsCollection(onlyTags)
+            # TODO: use some sort of default for bruse jsTags here?
+            file.jsTagOptions =
+              breakCodes: [32, 13, 9, 44] #space, enter, tab, comma
+              tags: file.unsavedTags
+              texts:
+                inputPlaceHolder: "Tag"
+            # append every file to the list of files
             $scope.files.push file
             )
           )
@@ -42,16 +53,12 @@
         win = window.open('/'+data.url, '_self')
         )
 
-  $scope.editTags = (file) ->
-    onlyTags = _.pluck(file.tags, 'name')
-    file.unsavedTags = new JSTagsCollection();
-    file.jsTagOptions =
-      "defaultTags": onlyTags
-      texts:
-        inputPlaceHolder: "Tag"
-      tags: file.unsavedTags
-      breakCodes: [32, 13, 9, 44] #space, enter, tab, comma
-    file.tagsEdit = true
+  $scope.saveTags = (file) ->
+    tagsToSave = file.unsavedTags.getTagValues()
+    TagHandler.put(file.id, tagsToSave).then((data) ->
+      file.tags = data.tags
+      file.editTags = false
+      )
 
   $scope.identities = ->
     return [] unless $scope.hasFiles()

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -59,6 +59,10 @@
       file.tags = data.tags
       file.editTags = false
       )
+
+  ###*
+   * Remove tag with id tag_id from file
+  ###
   $scope.cutTag = (file, tag_id) ->
     TagHandler.cut(file.id, tag_id).then((data) ->
       file.tags = data.tags

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -1,10 +1,9 @@
 # This provides the bFileList directive with some power
-@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', ($scope, $filter, FileHandler) ->
+@bruseApp.controller 'FileListCtrl', ['$scope', 'FileHandler', ($scope, FileHandler) ->
   # since we use 'this' in some function below, we need to make sure they are
   # use the the controller as the 'this', and not the function
   self = this
   # setup some vars
-  orderBy = $filter('orderBy')
   $scope.files = []
   $scope.view_list = true
 
@@ -48,8 +47,4 @@
 
   $scope.hasFiles = ->
     Array.isArray($scope.files) && $scope.files.length > 0
-
-  # a function to order the files
-  $scope.order = (predicate, reverse) ->
-    $scope.files = orderBy($scope.files, predicate, reverse)
 ]

--- a/app/assets/javascripts/factories/FileHandler.coffee
+++ b/app/assets/javascripts/factories/FileHandler.coffee
@@ -5,6 +5,7 @@
     # Collect saved BruseFiles from this identity or all
     #
     collect: ({identity, path, limit, offset} = {}) ->
+      # default params
       path ?= '/files.json'
       offset ?= 0
 

--- a/app/assets/javascripts/factories/FileHandler.coffee
+++ b/app/assets/javascripts/factories/FileHandler.coffee
@@ -4,10 +4,17 @@
     #
     # Collect saved BruseFiles from this identity or all
     #
-    collect: (identity) ->
-      path = if identity then '/service/'+identity.id+'/files.json' else '/files.json'
+    collect: ({identity, path, limit, offset} = {}) ->
+      path ?= '/files.json'
+      offset ?= 0
+
+      # prepare path to load from server
+      loadpath = if identity then '/service/'+identity.id+'/files.json' else path
+      # if limit is provided, send it with the request
+      loadpath += "?limit=#{limit}&offset=#{offset}" if limit
+
       # send a get request
-      promise = $http.get(path)
+      promise = $http.get(loadpath)
         .then((response) ->
           # return files
           response.data.files

--- a/app/assets/javascripts/factories/TagHandler.coffee
+++ b/app/assets/javascripts/factories/TagHandler.coffee
@@ -29,5 +29,14 @@
         .catch((response) ->
           console.error "An error occured."
           )
+
+    cut: (file_id, tag_id) ->
+      promise = $http.delete("/files/#{file_id}/tag/delete/#{tag_id}.json")
+        .then((response) ->
+          response.data
+          )
+        .catch((response) ->
+          console.error "An error occured.", response
+          )
   }
 ]

--- a/app/assets/javascripts/factories/TagHandler.coffee
+++ b/app/assets/javascripts/factories/TagHandler.coffee
@@ -21,6 +21,7 @@
           response
           )
 
+    # collect all files belonging to tag
     collectFiles: (tag_id) ->
       promise = $http.get("/tags/#{tag_id}.json")
         .then((response) ->
@@ -30,6 +31,7 @@
           console.error "An error occured."
           )
 
+    # delete a specific tag from a file's list of tags
     cut: (file_id, tag_id) ->
       promise = $http.delete("/files/#{file_id}/tag/delete/#{tag_id}.json")
         .then((response) ->

--- a/app/assets/javascripts/factories/TagHandler.coffee
+++ b/app/assets/javascripts/factories/TagHandler.coffee
@@ -2,7 +2,7 @@
   return {
     ###
     Add tags to a file
-      file_id:integer
+      file_id: integer
       tags: string[]
 
     Sends a post request with the data to the server
@@ -19,6 +19,15 @@
         .catch((response) ->
           alert "Couldn't add tags.."
           response
+          )
+
+    collectFiles: (tag_id) ->
+      promise = $http.get("/tags/#{tag_id}.json")
+        .then((response) ->
+          response.data
+          )
+        .catch((response) ->
+          console.error "An error occured."
           )
   }
 ]

--- a/app/assets/javascripts/filters/IdentityFilter.coffee
+++ b/app/assets/javascripts/filters/IdentityFilter.coffee
@@ -1,0 +1,8 @@
+@bruseApp.filter 'IdentityFilter', ->
+  (files, identities) ->
+    debugger
+    _.map(files, (file) ->
+      obj = {}
+      obj[file.identity.name] = true
+      _.includes(identities, obj)
+      )

--- a/app/assets/javascripts/filters/IdentityFilter.coffee
+++ b/app/assets/javascripts/filters/IdentityFilter.coffee
@@ -1,6 +1,5 @@
 @bruseApp.filter 'IdentityFilter', ->
   (files, identities) ->
-    debugger
     _.map(files, (file) ->
       obj = {}
       obj[file.identity.name] = true

--- a/app/assets/javascripts/vendor/jsTag.debug.js
+++ b/app/assets/javascripts/vendor/jsTag.debug.js
@@ -532,11 +532,7 @@ jsTag.controller('JSTagMainCtrl', ['$attrs', '$scope', 'InputService', 'TagsInpu
 
   // Use user defined options
   if (userOptions !== undefined) {
-    for (var key in options) {
-      if(userOptions[key]) {
-        options[key] = userOptions[key];
-      }
-    }
+    angular.extend(options, userOptions);
   }
 
   $scope.options = options;

--- a/app/assets/javascripts/vendor/jsTag.debug.js
+++ b/app/assets/javascripts/vendor/jsTag.debug.js
@@ -1,8 +1,8 @@
 /************************************************
-* jsTag JavaScript Library - Editing tags based on angularJS 
+* jsTag JavaScript Library - Editing tags based on angularJS
 * Git: https://github.com/eranhirs/jsTag/tree/master
 * License: MIT (http://www.opensource.org/licenses/mit-license.php)
-* Compiled At: 04/23/2015 11:03
+* Compiled At: 04/24/2015 11:49
 **************************************************/
 'use strict';
 var jsTag = angular.module('jsTag', []);
@@ -48,7 +48,7 @@ jsTag.filter('toArray', function() {
       var value = input[key];
       objectsAsArray.push(value);
     }
-  
+
     return objectsAsArray;
   };
 });
@@ -60,14 +60,14 @@ jsTag.factory('JSTag', function() {
     this.value = value;
     this.id = id;
   }
-  
+
   return JSTag;
 });
 var jsTag = angular.module('jsTag');
 
 // TagsCollection Model
 jsTag.factory('JSTagsCollection', ['JSTag', '$filter', function(JSTag, $filter) {
-  
+
   // Constructor
   function JSTagsCollection(defaultTags) {
     this.tags = {};
@@ -76,30 +76,30 @@ jsTag.factory('JSTagsCollection', ['JSTag', '$filter', function(JSTag, $filter) 
       var defaultTagValue = defaultTags[defaultTagKey];
       this.addTag(defaultTagValue);
     }
-   
+
     this._onAddListenerList = [];
     this._onRemoveListenerList = [];
- 
+
     this.unsetActiveTags();
     this.unsetEditedTag();
   }
-  
+
   // *** Methods *** //
-  
+
   // *** Object manipulation methods *** //
-  
+
   // Adds a tag with received value
   JSTagsCollection.prototype.addTag = function(value) {
     var tagIndex = this.tagsCounter;
     this.tagsCounter++;
-  
+
     var newTag = new JSTag(value, tagIndex);
     this.tags[tagIndex] = newTag;
     angular.forEach(this._onAddListenerList, function (callback) {
       callback(newTag);
     });
   }
-  
+
   // Removes the received tag
   JSTagsCollection.prototype.removeTag = function(tagIndex) {
     var tag = this.tags[tagIndex];
@@ -121,7 +121,16 @@ jsTag.factory('JSTagsCollection', ['JSTag', '$filter', function(JSTag, $filter) 
   JSTagsCollection.prototype.getNumberOfTags = function() {
     return getNumberOfProperties(this.tags);
   }
-  
+
+  // Returns an array with all values of the tags
+  JSTagsCollection.prototype.getTagValues = function() {
+    var tagValues = [];
+    for (var tag in this.tags) {
+      tagValues.push(this.tags[tag].value);
+    }
+    return tagValues;
+  }
+
   // Returns the previous tag before the tag received as input
   // Returns same tag if it's the first
   JSTagsCollection.prototype.getPreviousTag = function(tag) {
@@ -133,7 +142,7 @@ jsTag.factory('JSTagsCollection', ['JSTag', '$filter', function(JSTag, $filter) 
       return getPreviousProperty(this.tags, tag.id);
     }
   }
-  
+
   // Returns the next tag after  the tag received as input
   // Returns same tag if it's the last
   JSTagsCollection.prototype.getNextTag = function(tag) {
@@ -145,21 +154,21 @@ jsTag.factory('JSTagsCollection', ['JSTag', '$filter', function(JSTag, $filter) 
       return getNextProperty(this.tags, tag.id);
     }
   }
-  
+
   // *** Active methods *** //
-  
+
   // Checks if a specific tag is active
   JSTagsCollection.prototype.isTagActive = function(tag) {
     return $filter("inArray")(tag, this._activeTags);
   };
-  
+
   // Sets tag to active
   JSTagsCollection.prototype.setActiveTag = function(tag) {
     if (!this.isTagActive(tag)) {
       this._activeTags.push(tag);
     }
   };
-  
+
   // Sets the last tag to be active
   JSTagsCollection.prototype.setLastTagActive = function() {
     if (getNumberOfProperties(this.tags) > 0) {
@@ -167,49 +176,49 @@ jsTag.factory('JSTagsCollection', ['JSTag', '$filter', function(JSTag, $filter) 
       this.setActiveTag(lastTag);
     }
   };
-  
+
   // Unsets an active tag
   JSTagsCollection.prototype.unsetActiveTag = function(tag) {
     var removedTag = this._activeTags.splice(this._activeTags.indexOf(tag), 1);
   };
-  
+
   // Unsets all active tag
   JSTagsCollection.prototype.unsetActiveTags = function() {
     this._activeTags = [];
   };
-  
+
   // Returns a JSTag only if there is 1 exactly active tags, otherwise null
   JSTagsCollection.prototype.getActiveTag = function() {
     var activeTag = null;
     if (this._activeTags.length === 1) {
       activeTag = this._activeTags[0];
     }
-    
+
     return activeTag;
   };
-  
+
   // Returns number of active tags
   JSTagsCollection.prototype.getNumOfActiveTags = function() {
     return this._activeTags.length;
   };
-  
+
   // *** Edit methods *** //
-  
+
   // Gets the edited tag
   JSTagsCollection.prototype.getEditedTag = function() {
     return this._editedTag;
   };
-  
+
   // Checks if a tag is edited
   JSTagsCollection.prototype.isTagEdited = function(tag) {
     return tag === this._editedTag;
   };
-  
+
   // Sets the tag in the _editedTag member
   JSTagsCollection.prototype.setEditedTag = function(tag) {
     this._editedTag = tag;
   };
-  
+
   // Unsets the 'edit' flag on a tag by it's given index
   JSTagsCollection.prototype.unsetEditedTag = function() {
     // Kill empty tags!
@@ -218,10 +227,10 @@ jsTag.factory('JSTagsCollection', ['JSTag', '$filter', function(JSTag, $filter) 
         this._editedTag.value === "") {
       this.removeTag(this._editedTag.id);
     }
-    
+
     this._editedTag = null;
   }
-  
+
   return JSTagsCollection;
 }]);
 
@@ -306,7 +315,7 @@ jsTag.factory('InputService', ['$filter', function($filter) {
 
     } else {
       switch (keycode) {
-        case 9:	// Tab
+        case 9: // Tab
 
           break;
         case 37: // Left arrow
@@ -365,6 +374,11 @@ jsTag.factory('InputService', ['$filter', function($filter) {
 
       // Split value by spliter (usually ,)
       var values = originalValue.split(options.splitter);
+      for (var i = 0; i < values.length; i++) {
+        if (!values[i]) {
+          values.splice(i, 1);
+        }
+      }
 
       // Add tags to collection
       for (var key in values) {
@@ -512,32 +526,35 @@ jsTag.controller('JSTagMainCtrl', ['$attrs', '$scope', 'InputService', 'TagsInpu
   } catch(e) {
     console.log("jsTag Error: Invalid user options, using defaults only");
   }
-  
+
   // Copy so we don't override original values
   var options = angular.copy(jsTagDefaults);
-  
+
   // Use user defined options
   if (userOptions !== undefined) {
-    userOptions.texts = angular.extend(options.texts, userOptions.texts || {});
-    angular.extend(options, userOptions);
+    for (var key in options) {
+      if(userOptions[key]) {
+        options[key] = userOptions[key];
+      }
+    }
   }
-  
+
   $scope.options = options;
-  
+
   // Export handlers to view
   $scope.tagsInputService = new TagsInputService($scope.options);
   $scope.inputService = new InputService($scope.options);
-  
+
   // Export tagsCollection separately since it's used alot
   var tagsCollection = $scope.tagsInputService.tagsCollection;
   $scope.tagsCollection = tagsCollection;
-    
+
   // TODO: Should be inside inside tagsCollection.js
   // On every change to editedTags keep isThereAnEditedTag posted
   $scope.$watch('tagsCollection._editedTag', function(newValue, oldValue) {
     $scope.isThereAnEditedTag = newValue !== null;
   });
-  
+
   // TODO: Should be inside inside tagsCollection.js
   // On every change to activeTags keep isThereAnActiveTag posted
   $scope.$watchCollection('tagsCollection._activeTags', function(newValue, oldValue) {
@@ -568,7 +585,7 @@ jsTag.directive('ngBlur', ['$parse', function($parse) {
           // function name into an actual function
           var functionToCall = $parse(attrs.ngBlur);
           elem.bind('blur', function(event) {
-          
+
             // on the blur event, call my function
             scope.$apply(function() {
               functionToCall(scope, {$event:event});
@@ -590,11 +607,11 @@ jsTag.directive('focusMe', ['$parse', '$timeout', function($parse, $timeout) {
       scope.$watch(model, function(value) {
         if (value === true) {
           $timeout(function() {
-            element[0].focus(); 
+            element[0].focus();
           });
         }
       });
-      
+
       // to address @blesh's comment, set attribute value to 'false'
       // on blur event:
       element.bind('blur', function() {
@@ -623,9 +640,9 @@ jsTag.directive('autoGrow', ['$timeout', function($timeout) {
     link: function(scope, element, attr){
       var paddingLeft = element.css('paddingLeft'),
           paddingRight = element.css('paddingRight');
-   
+
       var minWidth = 60;
-   
+
       var $shadow = angular.element('<span></span>').css({
         'position': 'absolute',
         'top': '-10000px',
@@ -635,32 +652,32 @@ jsTag.directive('autoGrow', ['$timeout', function($timeout) {
         'white-space': 'pre'
       });
       element.after($shadow);
-   
+
       var update = function() {
         var val = element.val()
           .replace(/</g, '&lt;')
           .replace(/>/g, '&gt;')
           .replace(/&/g, '&amp;')
         ;
-        
+
         // If empty calculate by placeholder
         if (val !== "") {
           $shadow.html(val);
         } else {
           $shadow.html(element[0].placeholder);
         }
-        
+
         var newWidth = ($shadow[0].offsetWidth + 10) + "px";
         element.css('width', newWidth);
       }
-   
+
       var ngModel = element.attr('ng-model');
       if (ngModel) {
         scope.$watch(ngModel, update);
       } else {
         element.bind('keyup keydown', update);
       }
-      
+
       // Update on the first link
       // $timeout is needed because the value of element is updated only after the $digest cycle
       // TODO: Maybe on compile time if we call update we won't need $timeout
@@ -672,10 +689,10 @@ jsTag.directive('autoGrow', ['$timeout', function($timeout) {
 // Small directive for twitter's typeahead
 jsTag.directive('jsTagTypeahead', function () {
   return {
-    restrict: 'A', // Only apply on an attribute or class  
+    restrict: 'A', // Only apply on an attribute or class
     require: '?ngModel',  // The two-way data bound value that is returned by the directive
     link: function (scope, element, attrs, ngModel) {
-      
+
       element.bind('jsTag:breakcodeHit', function(event) {
 
         /* Do not clear typeahead input if typeahead option 'editable' is set to false
@@ -687,7 +704,7 @@ jsTag.directive('jsTagTypeahead', function () {
         // Tell typeahead to remove the value (after it was also removed in input)
         $(event.currentTarget).typeahead('val', '');
       });
-      
+
     }
   };
 });
@@ -801,5 +818,3 @@ angular.module("jsTag").run(["$templateCache", function($templateCache) {
   );
 
 }]);
-
-

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -7,10 +7,10 @@
   </button>
 
   <div class="filter">
-    <label ng-repeat="identity in identities()">
-      <input type="checkbox" checked="1" ng-model="showIdentities[identity.name]" />
-      {{identity.name}}
-    </label>
+    Showing files from
+    <select ng-model="identity_filter.identity.id" ng-options="i.id as i.name for i in identities()">
+      <option value="">--All--</option>
+    </select>
   </div>
 
   <div ng-if="view_list">
@@ -24,13 +24,13 @@
         <th>&nbsp;</th>
       </tr>
       <!-- this should be added in the future: | IdentityFilter:showIdentities -->
-      <tr ng-repeat="file in files | orderBy : order_by : reverse">
+      <tr ng-repeat="file in files | filter: identity_filter | orderBy : order_by : reverse">
           <td>
             <a ng-if="file.url" ng-href="{{file.url}}" target="_blank">
               <i class="fa fa-external-link"></i> {{file.name}}
             </a>
             <span ng-if="!file.url">
-              <a href="#" ng-click="download(file.identity.id, file)">
+              <a href="" ng-click="download(file.identity.id, file)">
                 <i class="fa fa-download"></i>
               </a>
               {{file.name}}

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -18,21 +18,18 @@
       </tr>
       <tr ng-repeat="file in files | orderBy : order_by : reverse">
           <td>
-            <a ng-if="file.filetype === 'bruse/url'" ng-href="{{file.url}}" target="_blank">
-              {{file.name}}
+            <a ng-if="file.url" ng-href="{{file.url}}" target="_blank">
+              <i class="fa fa-external-link"></i> {{file.name}}
             </a>
-            <a ng-if="file.filetype.indexOf('google-apps') > -1" ng-href="{{file.link}}" target="_blank">
-              {{file.name}}
-            </a>
-            <span ng-if="file.filetype != 'bruse/url' && file.filetype.indexOf('google-apps') < 0" ng-click="download(file.identity.id, file)">
+            <span ng-if="!file.url">
+              <a href="#" ng-click="download(file.identity.id, file)">
+                <i class="fa fa-download"></i>
+              </a>
               {{file.name}}
             </span>
           </td>
-          <td ng-if="file.filetype.indexOf('google-apps') > -1">
-            {{getFiletype(file.filetype).slice(16,end)}}
-          </td>
-          <td ng-if="file.filetype.indexOf('google-apps') < 0">
-            {{getFiletype(file.filetype)}}
+          <td>
+            {{file.filetype.indexOf('google-apps') > -1 ? getFiletype(file.filetype).slice(16,end) : getFiletype(file.filetype)}}
           </td>
           <td>
             <i class="fa fa-dropbox" ng-if="file.identity.service == 'dropbox_oauth2'"></i>

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -49,14 +49,23 @@
             <a ng-href="{{file.paths.add_tags}}" title="Add tags">
               <i class="fa fa-plus-square"></i>
             </a>
-            <span ng-repeat="tag in file.tags">
-              <a ng-href="{{tag.path}}">
-                #{{tag.name}}
-              </a>
-              <a ng-href="{{tag.destroy_path}}" data-method="delete">
-                <i class="fa fa-minus-square"></i>
-              </a>
+            <span ng-if="file.tagsEdit">
+              Edit!
+              <js-tag ng-if="file.tagsEdit" js-tag-options="file.jsTagOptions"></js-tag>
             </span>
+            <div class="file__taglist" ng-if="!file.tagsEdit">
+              <a ng-href="" title="Edit tags" ng-click="editTags(file)">
+                <i class="fa fa-pencil"></i>
+              </a>
+              <span ng-repeat="tag in file.tags">
+                <a ng-href="{{tag.path}}">
+                  #{{tag.name}}
+                </a>
+                <a ng-href="{{tag.destroy_path}}" data-method="delete">
+                  <i class="fa fa-minus-square"></i>
+                </a>
+              </span>
+            </div>
           </td>
           <td>
             <a ng-href="{{file.paths.file}}" data-method="delete" data-confirm="Are you sure?">

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -9,14 +9,14 @@
   <div ng-if="view_list">
     <table ng-if="hasFiles()">
       <tr>
-        <th><a href="" ng-click="reverse=!reverse;order('name', reverse)">Filename</a></th>
+        <th><a href="" ng-click="reverse = !reverse; order_by = 'name';">Filename</a></th>
         <th>Filetype</th>
-        <th><a href="" ng-click="reverse=!reverse;order('date', reverse)">Identity</a></th>
-        <th><a href="" ng-click="reverse=!reverse;order('date', reverse)">Date</a></th>
+        <th><a href="" ng-click="reverse = !reverse; order_by = 'identity.name';">Identity</a></th>
+        <th><a href="" ng-click="reverse = !reverse; order_by = 'date';">Date</a></th>
         <th>Tags</th>
         <th>&nbsp;</th>
       </tr>
-      <tr ng-repeat="file in files">
+      <tr ng-repeat="file in files | orderBy : order_by : reverse">
           <td>
             <a ng-if="file.filetype === 'bruse/url'" ng-href="{{file.url}}" target="_blank">
               {{file.name}}

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -64,7 +64,7 @@
               <a ng-href="{{tag.path}}">
                 #{{tag.name}}
               </a>
-              <a ng-href="{{tag.destroy_path}}" data-method="delete">
+              <a ng-click="cutTag(file, tag.id)">
                 <i class="fa fa-minus-square"></i>
               </a>
             </span>

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -6,6 +6,13 @@
     Block
   </button>
 
+  <div class="filter">
+    <label ng-repeat="identity in identities()">
+      <input type="checkbox" checked="1" ng-model="showIdentities[identity.name]" />
+      {{identity.name}}
+    </label>
+  </div>
+
   <div ng-if="view_list">
     <table ng-if="hasFiles()">
       <tr>
@@ -16,6 +23,7 @@
         <th>Tags</th>
         <th>&nbsp;</th>
       </tr>
+      <!-- this should be added in the future: | IdentityFilter:showIdentities -->
       <tr ng-repeat="file in files | orderBy : order_by : reverse">
           <td>
             <a ng-if="file.url" ng-href="{{file.url}}" target="_blank">

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -40,8 +40,11 @@
           {{getFiletype(file.filetype)}}
         </td>
         <td>
-          <i class="fa fa-dropbox" ng-if="file.identity.service == 'dropbox_oauth2'"></i>
-          <i class="fa fa-google" ng-if="file.identity.service == 'google_oauth2'"></i>
+          <span ng-switch="file.identity.service">
+            <i class="fa fa-dropbox" ng-switch-when="dropbox_oauth2"></i>
+            <i class="fa fa-google" ng-switch-when="google_oauth2"></i>
+            <i ng-switch-default></i>
+          </span>
           {{file.identity.name}}
         </td>
         <td>{{file.date}}</td>

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -26,7 +26,11 @@
             </span>
           </td>
           <td>.{{getFiletype(file.filetype)}}</td>
-          <td>{{file.identity.name}}</td>
+          <td>
+            <i class="fa fa-dropbox" ng-if="file.identity.service == 'dropbox_oauth2'"></i>
+            <i class="fa fa-google" ng-if="file.identity.service == 'google_oauth2'"></i>
+            {{file.identity.name}}
+          </td>
           <td>{{file.date}}</td>
           <td>
             <a ng-href="{{file.paths.add_tags}}" title="Add tags">

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -25,53 +25,56 @@
       </tr>
       <!-- this should be added in the future: | IdentityFilter:showIdentities -->
       <tr ng-repeat="file in files | filter: identity_filter | orderBy : order_by : reverse">
-          <td>
-            <a ng-if="file.url" ng-href="{{file.url}}" target="_blank">
-              <i class="fa fa-external-link"></i> {{file.name}}
+        <td>
+          <a ng-if="file.url" ng-href="{{file.url}}" target="_blank">
+            <i class="fa fa-external-link"></i> {{file.name}}
+          </a>
+          <span ng-if="!file.url">
+            <a href="" ng-click="download(file.identity.id, file)">
+              <i class="fa fa-download"></i>
             </a>
-            <span ng-if="!file.url">
-              <a href="" ng-click="download(file.identity.id, file)">
-                <i class="fa fa-download"></i>
+            {{file.name}}
+          </span>
+        </td>
+        <td>
+          {{file.filetype.indexOf('google-apps') > -1 ? getFiletype(file.filetype).slice(16,end) : getFiletype(file.filetype)}}
+        </td>
+        <td>
+          <i class="fa fa-dropbox" ng-if="file.identity.service == 'dropbox_oauth2'"></i>
+          <i class="fa fa-google" ng-if="file.identity.service == 'google_oauth2'"></i>
+          {{file.identity.name}}
+        </td>
+        <td>{{file.date}}</td>
+        <td>
+          <a ng-href="{{file.paths.add_tags}}" title="Add tags">
+            <i class="fa fa-plus-square"></i>
+          </a>
+          <span ng-show="file.editTags">
+            <js-tag js-tag-options="file.jsTagOptions"></js-tag>
+            <button ng-click="saveTags(file)">
+              <i class="fa fa-check-circle"></i>
+              Save
+            </button>
+          </span>
+          <div class="file__taglist" ng-hide="file.editTags">
+            <a ng-href="" title="Edit tags" ng-click="file.editTags = true">
+              <i class="fa fa-pencil"></i>
+            </a>
+            <span ng-repeat="tag in file.tags">
+              <a ng-href="{{tag.path}}">
+                #{{tag.name}}
               </a>
-              {{file.name}}
-            </span>
-          </td>
-          <td>
-            {{file.filetype.indexOf('google-apps') > -1 ? getFiletype(file.filetype).slice(16,end) : getFiletype(file.filetype)}}
-          </td>
-          <td>
-            <i class="fa fa-dropbox" ng-if="file.identity.service == 'dropbox_oauth2'"></i>
-            <i class="fa fa-google" ng-if="file.identity.service == 'google_oauth2'"></i>
-            {{file.identity.name}}
-          </td>
-          <td>{{file.date}}</td>
-          <td>
-            <a ng-href="{{file.paths.add_tags}}" title="Add tags">
-              <i class="fa fa-plus-square"></i>
-            </a>
-            <span ng-if="file.tagsEdit">
-              Edit!
-              <js-tag ng-if="file.tagsEdit" js-tag-options="file.jsTagOptions"></js-tag>
-            </span>
-            <div class="file__taglist" ng-if="!file.tagsEdit">
-              <a ng-href="" title="Edit tags" ng-click="editTags(file)">
-                <i class="fa fa-pencil"></i>
+              <a ng-href="{{tag.destroy_path}}" data-method="delete">
+                <i class="fa fa-minus-square"></i>
               </a>
-              <span ng-repeat="tag in file.tags">
-                <a ng-href="{{tag.path}}">
-                  #{{tag.name}}
-                </a>
-                <a ng-href="{{tag.destroy_path}}" data-method="delete">
-                  <i class="fa fa-minus-square"></i>
-                </a>
-              </span>
-            </div>
-          </td>
-          <td>
-            <a ng-href="{{file.paths.file}}" data-method="delete" data-confirm="Are you sure?">
-              <i class="fa fa-trash"></i>
-            </a>
-          </td>
+            </span>
+          </div>
+        </td>
+        <td>
+          <a ng-href="{{file.paths.file}}" data-method="delete" data-confirm="Are you sure?">
+            <i class="fa fa-trash"></i>
+          </a>
+        </td>
       </tr>
      </table>
   </div>

--- a/app/controllers/files/files_controller.rb
+++ b/app/controllers/files/files_controller.rb
@@ -17,8 +17,11 @@ class Files::FilesController < ApplicationController
   end
 
   def show_all
+    limit = params.has_key?(:limit) ? params[:limit] : 200
+    offset = params.has_key?(:offset) ? params[:offset] : 0
+
     @bruse_file = BruseFile.new
-    @bruse_files = current_user.bruse_files.includes(:tags)
+    @bruse_files = current_user.bruse_files.includes(:tags).order(created_at: :desc).limit(limit.to_i).offset(offset.to_i)
   end
 
   def new

--- a/app/controllers/files/files_controller.rb
+++ b/app/controllers/files/files_controller.rb
@@ -18,7 +18,7 @@ class Files::FilesController < ApplicationController
 
   def show_all
     @bruse_file = BruseFile.new
-    @bruse_files = current_user.bruse_files
+    @bruse_files = current_user.bruse_files.includes(:tags)
   end
 
   def new

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,7 +1,7 @@
 class TagsController < ApplicationController
   before_action :set_tag, only: [:show]
   before_action :set_file, only: [:new, :create, :destroy]
-  skip_before_action :verify_authenticity_token, only: :create
+  skip_before_action :verify_authenticity_token, only: [:create, :destroy]
 
   def index
   end
@@ -22,7 +22,7 @@ class TagsController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to bruse_files_path, notice: 'Tag was successfully created.' }
-      format.json { render :create, status: :ok }
+      format.json { render partial: 'tags/file.json', status: :ok }
     end
   end
 
@@ -35,7 +35,7 @@ class TagsController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to bruse_files_url, notice: 'Deleted tag: ' + @tag.name.to_s }
-      format.json { head :no_content }
+      format.json { render partial: 'tags/file.json', status: :accepted }
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -16,20 +16,20 @@ class TagsController < ApplicationController
   def create
     if current_user.id == @file.identity.user_id
       params[:tags].each do |tag|
-        @tag = Tag.find_or_create_by(:name => tag)
+        @tag = Tag.find_or_create_by(name: tag)
         @tag.bruse_files << @file
       end
     end
 
-     respond_to do |format|
-        if @tag.save
-          format.html { redirect_to bruse_files_path, notice: 'Tag was successfully created.' }
-          format.json { render json: {:success => true}, status: :ok }
-        else
-          format.html { render :new, notice: 'Something went wrong' }
-          format.json { render json: {:errors => @tag.errors, :success => false}, status: :unprocessable_entity }
-        end
-     end
+    respond_to do |format|
+      if @tag.save
+        format.html { redirect_to bruse_files_path, notice: 'Tag was successfully created.' }
+        format.json { render json: { success: true, tags: @file.tags }, status: :ok }
+      else
+        format.html { render :new, notice: 'Something went wrong' }
+        format.json { render json: { errors: @tag.errors, success: false }, status: :unprocessable_entity }
+      end
+    end
   end
 
   def destroy
@@ -40,7 +40,7 @@ class TagsController < ApplicationController
     end
 
     respond_to do |format|
-      format.html { redirect_to bruse_files_url, notice: 'Deleted tag: ' + @tag.name.to_s}
+      format.html { redirect_to bruse_files_url, notice: 'Deleted tag: ' + @tag.name.to_s }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,24 +1,19 @@
 class TagsController < ApplicationController
-	before_action :set_tag , only: [:show]
+  before_action :set_tag, only: [:show]
+  before_action :set_file, only: [:new, :create, :destroy]
   skip_before_action :verify_authenticity_token, only: :create
 
   def index
-
   end
 
-	def show
-
+  def show
   end
 
   def new
     @tag = Tag.new
-    @file = BruseFile.find(params[:file_id])
-
   end
 
   def create
-    @file = BruseFile.find_by(:id => params[:file_id])
-
     if current_user.id == @file.identity.user_id
       params[:tags].each do |tag|
         @tag = Tag.find_or_create_by(:name => tag)
@@ -37,16 +32,11 @@ class TagsController < ApplicationController
      end
   end
 
-
   def destroy
-
-    @file = BruseFile.find(params[:file_id])
-
     @tag = @file.tags.find(params[:id])
 
-
     if @tag
-        @file.tags.delete(@tag)
+      @file.tags.delete(@tag)
     end
 
     respond_to do |format|
@@ -56,14 +46,16 @@ class TagsController < ApplicationController
   end
 
 
-private
+  private
+    def set_tag
+      @tag = Tag.find(params[:id])
+    end
 
-  def set_tag
-	  @tag = Tag.find(params[:id])
-	end
+    def set_file
+      @file = BruseFile.find(params[:file_id])
+    end
 
-	def tag_params
+    def tag_params
       params.require(:tag).permit(:name, :file_id)
-  end
-
+    end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -14,21 +14,15 @@ class TagsController < ApplicationController
   end
 
   def create
-    if current_user.id == @file.identity.user_id
-      params[:tags].each do |tag|
-        @tag = Tag.find_or_create_by(name: tag)
-        @tag.bruse_files << @file
-      end
+    tags = []
+    params[:tags].each do |tag|
+      tags << Tag.find_or_create_by(name: tag)
     end
+    @file.tags.replace(tags)
 
     respond_to do |format|
-      if @tag.save
-        format.html { redirect_to bruse_files_path, notice: 'Tag was successfully created.' }
-        format.json { render json: { success: true, tags: @file.tags }, status: :ok }
-      else
-        format.html { render :new, notice: 'Something went wrong' }
-        format.json { render json: { errors: @tag.errors, success: false }, status: :unprocessable_entity }
-      end
+      format.html { redirect_to bruse_files_path, notice: 'Tag was successfully created.' }
+      format.json { render :create, status: :ok }
     end
   end
 
@@ -45,14 +39,18 @@ class TagsController < ApplicationController
     end
   end
 
-
   private
+
     def set_tag
       @tag = Tag.find(params[:id])
     end
 
     def set_file
       @file = BruseFile.find(params[:file_id])
+      unless current_user.id == @file.identity.user_id
+        flash[:alert] = 'Access denied'
+        redirect_to root
+      end
     end
 
     def tag_params

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,4 +16,13 @@ class Tag < ActiveRecord::Base
     end
     results.uniq
   end
+
+  # Public: Get the files belonging to this tag and to and to the user
+  #
+  # user  - the user
+  #
+  # Returns the files, if any
+  def user_files(user)
+    bruse_files.joins(:identity).where(identities: { user_id: user.id })
+  end
 end

--- a/app/views/files/files/_file.json.jbuilder
+++ b/app/views/files/files/_file.json.jbuilder
@@ -1,9 +1,9 @@
 json.name file.name
 json.filetype file.filetype
-json.date file.created_at.strftime("%F %R")
+json.date file.created_at.strftime('%F %R')
 json.id file.id
 json.url file.link if file.link?
-json.url file.foreign_ref if file.filetype == "bruse/url"
+json.url file.foreign_ref if file.filetype == 'bruse/url'
 json.add_tags_path
 json.paths do
   json.file file_path(file.identity, file)

--- a/app/views/files/files/_file.json.jbuilder
+++ b/app/views/files/files/_file.json.jbuilder
@@ -2,7 +2,7 @@ json.name file.name
 json.filetype file.filetype
 json.date file.created_at.strftime("%F %R")
 json.id file.id
-json.link file.link if file.link?
+json.url file.link if file.link?
 json.url file.foreign_ref if file.filetype == "bruse/url"
 json.add_tags_path
 json.paths do

--- a/app/views/files/files/_file.json.jbuilder
+++ b/app/views/files/files/_file.json.jbuilder
@@ -11,6 +11,7 @@ end
 json.identity do
   json.id file.identity.id
   json.name file.identity.name
+  json.service file.identity.service
 end
 json.tags file.tags do |tag|
   json.name tag.name

--- a/app/views/files/files/_file.json.jbuilder
+++ b/app/views/files/files/_file.json.jbuilder
@@ -15,6 +15,7 @@ json.identity do
   json.service file.identity.service
 end
 json.tags file.tags do |tag|
+  json.id tag.id
   json.name tag.name
   json.path tag_path(tag)
   json.destroy_path destroy_tag_path(file, tag)

--- a/app/views/files/files/_file.json.jbuilder
+++ b/app/views/files/files/_file.json.jbuilder
@@ -2,7 +2,7 @@ json.name file.name
 json.filetype file.filetype
 json.date file.created_at.strftime('%F %R')
 json.id file.id
-json.url file.link if file.link?
+json.url file.link if file.link? && file.filetype.downcase.include?('google-apps')
 json.url file.foreign_ref if file.filetype == 'bruse/url'
 json.add_tags_path
 json.paths do

--- a/app/views/files/files/show_all.json.jbuilder
+++ b/app/views/files/files/show_all.json.jbuilder
@@ -1,4 +1,15 @@
-json.files @bruse_files do |file|
-  # use file partial for each file
-  json.partial! 'files/files/file', file: file
+json.files do
+  # using cache could/should improve performance for the partials
+  json.cache! @bruse_files do
+    # use file partial for each file
+    json.partial! 'files/files/file', collection: @bruse_files, as: :file
+  end
 end
+
+# this is an alternative caching sollution
+# json.files @bruse_files do |file|
+#   # use file partial for each file
+#   json.cache! file do
+#     json.partial! 'files/files/file', file: file
+#   end
+# end

--- a/app/views/tags/_file.json.jbuilder
+++ b/app/views/tags/_file.json.jbuilder
@@ -1,4 +1,5 @@
 json.tags @file.tags do |tag|
+  json.id tag.id
   json.name tag.name
   json.path tag_path(tag)
   json.destroy_path destroy_tag_path(@file, tag)

--- a/app/views/tags/create.json.jbuilder
+++ b/app/views/tags/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.tags @file.tags do |tag|
+  json.name tag.name
+  json.path tag_path(tag)
+  json.destroy_path destroy_tag_path(@file, tag)
+end

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,39 +1,5 @@
+<h1>
+  Tag: #<%= @tag.name %>
+</h1>
 
-
-<table>
-  <thead>
-   <strong>Tags: <%= @tag.name %></strong>
-    <tr>
-      <th>File name</th>
-      <th>File type</th>
-      <th>Meta</th>
-      <th>Unlink</th>
-
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <p>
-
-      <% @tag.bruse_files.each do |f| %>
-        <tr>
-          <td><%= f.name %></td>
-          <td><%= f.filetype %></td>
-          <td><%= f.meta %></td>
-          <td> <%= link_to 'Delete tag', destroy_tag_path(f, @tag),
-                  method: :delete,
-                  data: { confirm: 'Are you sure?' } %>
-          </td>
-        </tr>
-      <% end %>
-    </p>
-  </tbody>
-</table>
-
-
-
-<br>
-
-
-<%= link_to 'Back', bruse_files_path %>
+<b-file-list path="<%= tag_path @tag, format: :json %>"></b-file-list>

--- a/app/views/tags/show.json.jbuilder
+++ b/app/views/tags/show.json.jbuilder
@@ -1,5 +1,5 @@
 json.tag @tag
-json.files @tag.bruse_files do |file|
+json.files @tag.user_files(current_user) do |file|
   # use file partial for each file
   json.partial! 'files/files/file', file: file
 end

--- a/app/views/tags/show.json.jbuilder
+++ b/app/views/tags/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.tag @tag
+json.files @tag.bruse_files do |file|
+  # use file partial for each file
+  json.partial! 'files/files/file', file: file
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,27 +1,26 @@
 Rails.application.routes.draw do
-  # The priority is based upon order of creation: first created -> highest priority.
-  # See how all your routes lay out with "rake routes".
-
+  # root
   root 'pages#show', page: 'home'
-
-  resources :tags, except: :new
-
-  get '/tag/new/:file_id', to: 'tags#new', as: 'new_tag'
-  delete '/file/:file_id/tag/delete/:id', to: 'tags#destroy', as: 'destroy_tag'
 
   # User
   devise_for :users, controllers: { omniauth_callbacks: 'user/omniauth_callbacks',
-                                    registrations: 'user/registrations',
-                                    passwords: 'user/passwords' }
+                                    registrations:      'user/registrations',
+                                    passwords:          'user/passwords' }
   get '/user', to: 'user/users#show', as: 'profile'
   get '/users/terminate', to: 'user/users#terminate', as: 'terminate_user'
   delete '/users', to: 'user/users#destroy', as: 'destroy_user'
 
+  # Tags
+  resources :tags, except: [:new, :destroy]
+  delete '/files/:file_id/tag/delete/:id', to: 'tags#destroy', as: 'destroy_tag'
+  get '/tag/new/:file_id', to: 'tags#new', as: 'new_tag'
+
   # Provider
   delete '/provider/:id', to: 'identities#destroy', as: 'destroy_provider'
 
-  # all controllers located in the files folder
+  # all controllers/methods located in the files folder
   scope module: :files do
+    # all urls beginning with /service/number/...
     scope '/service/:identity_id' do
       # get folder contents
       get '/files/browse', to: 'browse#browse'
@@ -30,19 +29,19 @@ Rails.application.routes.draw do
       resources :files, except: :update, path_names: { new: 'add' }
       get '/files/add/tag', to: 'files#new'
     end
-    post '/create_file', to: 'files#create_from_text', defaults: { format: 'json' }
+
     # downloads a file
-    get '/get/:download_hash(/:name)', to: 'download#download', :via => :all
+    get '/get/:download_hash(/:name)', to: 'download#download', via: :all
 
+    # uploads
+    post '/create_file', to: 'files#create_from_text', defaults: { format: 'json' }
     post '/upload', to: 'browse#upload', as: 'upload'
-
     post '/upload_drop', to: 'browse#upload_from_base64', as: 'upload_drop'
 
+    # user file index
     get '/files', to: 'files#show_all', as: 'bruse_files'
-
   end
   # search
   post '/search', to: 'search#find', defaults: { format: 'json' }, as: 'search_find'
   get '/search', to: 'search#home', as: 'search'
-
 end


### PR DESCRIPTION
This PR improves the file list template, more specifically by these features:
- Do not load all files at once, collect them 20 (or whatever) at a time
- Improves server-side database performance by prefetching the tags belonging to each collected file, instead of collecting them in separate database calls for each file. Also, use JBuilder caching more efficiently.
- Tags can be edited from the file list
- Reuse some file paramaters
- Use the file list template while looking at files belonging to a certain tag
