### PR TITLE
Add FilePreviewer factory

### DIFF
--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -1,5 +1,5 @@
 # This provides the bFileList directive with some power
-@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', 'MimeDictionary', ($scope, $filter, FileHandler, MimeDictionary) ->
+@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', 'MimeDictionary', 'FilePreviewer', ($scope, $filter, FileHandler, MimeDictionary, FilePreviewer) ->
   # since we use 'this' in some function below, we need to make sure they are
   # use the the controller as the 'this', and not the function
   self = this;
@@ -28,6 +28,10 @@
         # open the returned url in a new tab
         win = window.open('/'+data.url, '_self')
         )
+
+  $scope.previewFile = (file) ->
+    # call file previewer
+    FilePreviewer(file, { scope: $scope })
 
   # change mime to only filetype
   $scope.getFiletype = (mimetype) ->

--- a/app/assets/javascripts/factories/FilePreviewer.coffee
+++ b/app/assets/javascripts/factories/FilePreviewer.coffee
@@ -1,0 +1,49 @@
+@bruseApp.factory 'FilePreviewer', ['MimeDictionary', (MimeDictionary) ->
+  # all our previewers
+  _previewers =
+    ###*
+     * display an image popup
+     * @param  object file   the file object
+     * @param  object params optional file parameters
+     * @return nothing
+    ###
+    image: (file, params) ->
+      console.log "Displaying image ", file.name
+
+    ###*
+     * display an image popup
+     * @param  object file   the file object
+     * @param  object params optional file parameters
+     * @return nothing
+    ###
+    plaintext: (file, params) ->
+      console.log "Displaying textfile ", file.name
+
+    ###*
+     * display an image popup
+     * @param  object file   the file object
+     * @param  object params optional file parameters
+     * @return nothing
+    ###
+    pdf: (file, params) ->
+      console.log "Displaying pdf ", file.name
+
+    ###*
+     * display default error that there is no preview for this file
+     * @param  object file   the file object
+     * @param  object params optional file parameters
+     * @return nothing
+    ###
+    noTemplate: (file, params) ->
+      # display something about not beeing able to display that file
+      console.warn "Template for filetype '#{file.filetype}' not found."
+
+  # return function to call from external resources
+  return (file, params) ->
+    # default params value
+    params ?= {}
+    # get template function name
+    templateName = MimeDictionary.viewTemplate(file.filetype)
+    # call template function
+    _previewers[templateName](file, params)
+]

--- a/app/assets/javascripts/factories/MimeDictionary.coffee
+++ b/app/assets/javascripts/factories/MimeDictionary.coffee
@@ -134,6 +134,7 @@
     'text/css': 'plaintext'
     'text/csv': 'plaintext'
     'text/x-c': 'plaintext'
+    'text/x-csrc': 'plaintext'
     'text/plain': 'plaintext'
     'text/xml': 'plaintext'
     'application/x-javascript': 'plaintext'

--- a/app/assets/javascripts/factories/MimeDictionary.coffee
+++ b/app/assets/javascripts/factories/MimeDictionary.coffee
@@ -172,8 +172,7 @@
      * @return string             template name, or null if not found
     ###
     viewTemplate: (mimetype) ->
-      if _templateNames[mimetype]
-        return _templateNames[mimetype]
-      return null
+      # return template function name if there is any
+      if _templateNames[mimetype] then _templateNames[mimetype] else 'noTemplate'
   }
 ]

--- a/app/assets/templates/file_list.html
+++ b/app/assets/templates/file_list.html
@@ -21,6 +21,7 @@
             <a ng-if="file.filetype === 'bruse/url'" ng-href="{{file.url}}" target="_blank">
               {{file.name}}
             </a>
+            <a ng-click="previewFile(file)">Preview</a>
             <a ng-if="file.filetype.indexOf('google-apps') > -1" ng-href="{{file.link}}" target="_blank">
               {{file.name}}
             </a>


### PR DESCRIPTION
It's using MimeDictionary to use different functions for different file types.

Basically, it's used like this:

``` coffee
# preview file and send optional parameters
FilePreviewer(file, { scope: $scope })
```
