### PR TITLE
default identity set in upload controller

### DIFF
--- a/app/controllers/files/upload_controller.rb
+++ b/app/controllers/files/upload_controller.rb
@@ -10,6 +10,10 @@ class Files::UploadController < Files::FilesController
   def upload
     identity = Identity.find(params[:service])
 
+    # Set default identity id
+    identity.user.default_identity_id = identity.id
+    identity.user.save!
+
     if params[:bruse_file].blank?
       flash[:notice] = "Choose a file"
       redirect_to bruse_files_path

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -203,9 +203,6 @@ class Identity < ActiveRecord::Base
   def upload_to_dropbox(file)
     set_client
 
-    self.user.default_identity_id = self.id
-    self.user.save!
-
     begin
       response = @client.put_file("/Bruse/#{file.original_filename}", file.tempfile)
     rescue
@@ -221,9 +218,6 @@ class Identity < ActiveRecord::Base
 
   def upload_to_google(localFile)
     set_client
-    
-    self.user.default_identity_id = self.id
-    self.user.save!
 
     drive = @client.discovered_api('drive', 'v2')
 


### PR DESCRIPTION
Changed the location of the code for setting default identity id so that it includes Bruse and to avoid writing the same lines of code.

Test this by:
Uploading files to the different services and the radio button should stay at the chosen service after upload.
