### PR TITLE
Fix/filetype in filelist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'jquery-turbolinks'
 # Loading indicator for turbolinks
 gem 'nprogress-rails'
 # Use Angular for nice dom manipulation
-gem 'angularjs-rails'
+gem 'angularjs-rails', '~> 1.4.0'
 # Lodash is a nice javascript toolbelt
 gem 'lodash-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    angularjs-rails (1.3.15)
+    angularjs-rails (1.4.0)
     arel (6.0.0)
     autoparse (0.3.3)
       addressable (>= 2.3.1)
@@ -321,7 +321,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import (~> 0.4.0)
-  angularjs-rails
+  angularjs-rails (~> 1.4.0)
   better_errors
   bourbon
   byebug

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -76,10 +76,7 @@
     FileHandler.update(file).then((data) ->
       # re-create our file, but maintain what angular knows about it
       file = angular.merge(file, FilePreparer(data.file))
-      # _f = FilePreparer(data.file)
       file.editFile = false
-      debugger
-      # return _f
     )
 
   $scope.deleteFile = ($event, file) ->

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -74,24 +74,12 @@
 
   $scope.saveFile = (file) ->
     FileHandler.update(file).then((data) ->
-      newFile = data.file
-      file.editFile = false
-      file.name = newFile.name
-      # extract tag names
-      onlyTags = _.pluck(newFile.tags, 'name')
-      # append jsTag stuff to every file
-      file.unsavedTags = new JSTagsCollection(onlyTags)
-      # load global default for jsTagOptions
-      file.jsTagOptions = angular.copy(defaults.jsTagOptions)
-      # append unsaved tags
-      file.jsTagOptions.tags = file.unsavedTags
-      file.tags = newFile.tags
       # # re-create our file, but maintain what angular knows about it
-      # fileangular.merge(file, FilePreparer(data.file))
-      # # _f = FilePreparer(data.file)
-      # file.editFile = false
-      # debugger
-      # # return _f
+      file = angular.merge(file, FilePreparer(data.file))
+      # _f = FilePreparer(data.file)
+      file.editFile = false
+      debugger
+      # return _f
     )
 
   $scope.deleteFile = ($event, file) ->

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -74,7 +74,7 @@
 
   $scope.saveFile = (file) ->
     FileHandler.update(file).then((data) ->
-      # # re-create our file, but maintain what angular knows about it
+      # re-create our file, but maintain what angular knows about it
       file = angular.merge(file, FilePreparer(data.file))
       # _f = FilePreparer(data.file)
       file.editFile = false

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -115,4 +115,6 @@
 
   $scope.editing = ->
     _.any($scope.files, 'editFile': true)
+
+  return
 ]

--- a/app/assets/javascripts/controllers/FileListCtrl.coffee
+++ b/app/assets/javascripts/controllers/FileListCtrl.coffee
@@ -1,5 +1,5 @@
 # This provides the bFileList directive with some power
-@bruseApp.controller 'FileListCtrl', ['$scope', '$filter', 'FileHandler', 'TagHandler', 'FilePreparer', 'MimeDictionary', 'FilePreviewer', 'defaults', '$parse',($scope, $filter, FileHandler, TagHandler, FilePreparer, MimeDictionary, FilePreviewer, defaults, $parse) ->
+@bruseApp.controller 'FileListCtrl', ['$scope', 'FileHandler', 'FilePreparer', 'FilePreviewer', 'defaults', '$parse', 'JSTagsCollection', ($scope, FileHandler, FilePreparer, FilePreviewer, defaults, $parse, JSTagsCollection) ->
   # since we use 'this' in some function below, we need to make sure they are
   # use the the controller as the 'this', and not the function
   self = this
@@ -72,13 +72,6 @@
     # call file previewer
     FilePreviewer(file, { scope: $scope })
 
-  $scope.saveTags = (file) ->
-    tagsToSave = file.unsavedTags.getTagValues()
-    TagHandler.put(file.id, tagsToSave).then((data) ->
-      file.tags = data.tags
-      file.editFile = false
-      )
-
   $scope.saveFile = (file) ->
     FileHandler.update(file).then((data) ->
       newFile = data.file
@@ -93,6 +86,12 @@
       # append unsaved tags
       file.jsTagOptions.tags = file.unsavedTags
       file.tags = newFile.tags
+      # # re-create our file, but maintain what angular knows about it
+      # fileangular.merge(file, FilePreparer(data.file))
+      # # _f = FilePreparer(data.file)
+      # file.editFile = false
+      # debugger
+      # # return _f
     )
 
   $scope.deleteFile = ($event, file) ->
@@ -110,10 +109,6 @@
     return [] unless $scope.hasFiles()
     uniqueIdentities = _.uniq($scope.files, 'identity.name')
     _.pluck(uniqueIdentities, 'identity')
-
-  # change mime to only filetype
-  $scope.getFiletype = (mimetype) ->
-    MimeDictionary.prettyType(mimetype)
 
   $scope.hasFiles = ->
     Array.isArray($scope.files) && $scope.files.length > 0

--- a/app/assets/javascripts/factories/FilePreparer.coffee
+++ b/app/assets/javascripts/factories/FilePreparer.coffee
@@ -1,16 +1,15 @@
-@bruseApp.factory 'FilePreparer', ['JSTagsCollection', (JSTagsCollection) ->
+@bruseApp.factory 'FilePreparer', ['JSTagsCollection', 'MimeDictionary', 'defaults', (JSTagsCollection, MimeDictionary, defaults) ->
   return (file) ->
     _f = file
     # extract tag names
     onlyTags = _.pluck(file.tags, 'name')
+    # add pretty file type
+    _f.prettyFiletype = MimeDictionary.prettyType(file.filetype)
     # append jsTag stuff to every file
     _f.unsavedTags = new JSTagsCollection(onlyTags)
-    # TODO: use some sort of default for bruse jsTags here?
-    _f.jsTagOptions =
-      breakCodes: [32, 13, 9, 44] #space, enter, tab, comma
-      tags: _f.unsavedTags
-      texts:
-        inputPlaceHolder: "Tags..."
-        removeSymbol: String.fromCharCode(215)
+    # load global default for jsTagOptions
+    _f.jsTagOptions = angular.copy(defaults.jsTagOptions)
+    # append unsaved tags
+    _f.jsTagOptions.tags = _f.unsavedTags
     return _f
 ]

--- a/app/views/files/create_text/_create_from_textbox.html.erb
+++ b/app/views/files/create_text/_create_from_textbox.html.erb
@@ -1,11 +1,13 @@
 <% if current_user.local_identity %>
-  <form ng-controller="CreateFromTextCtrl">
-    <div class="notice" ng-if="message">{{message}}</div>
-    <div class="notice" ng-if="url">It looks to us as if you're about to save a link.</div>
-    <textarea placeholder="Paste/write your text here..." ng-model="text" ng-disabled="{{loading}}"></textarea>
-    <button ng-click="save()" type="button" class="green">
-      <%= fa_icon 'check' %>
-      Save
-    </button>
-  </form>
+  <div ng-controller="CreateFromTextCtrl">
+    <form ng-submit="save()">
+      <div class="notice" ng-if="message">{{message}}</div>
+      <div class="notice" ng-if="url">It looks to us as if you're about to save a link.</div>
+      <textarea placeholder="Paste/write your text here..." ng-model="text" ng-disabled="{{loading}}"></textarea>
+      <button class="green">
+        <%= fa_icon 'check' %>
+        Save
+      </button>
+    </form>
+  </div>
 <% end %>


### PR DESCRIPTION
Make sure the filetype is available in the file list by using `FilePreparer` in a larger extent.

Also, this bumps angular from `1.3.15` to the brand new shiny `1.4.0` (needed to make the `FilePreparer` work as intended).
